### PR TITLE
Adding support for optional attendees for a meeting

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -25,11 +25,11 @@ public final class FindMeetingQuery {
   public ArrayList<TimeRange> getAvailableTimes(Collection<Event> events, Collection<String> attendees, long duration) {
     ArrayList<TimeRange> availableTimes = new ArrayList<TimeRange>();
     ArrayList<TimeRange> blockedTimes = new ArrayList<TimeRange>();
-    //Set<String> r_attendees = new HashSet<String>(request.getAttendees());      
+        
     for (Event e : events) { // check each event of the day for blocked times
-      Set<String> e_attendees = new HashSet<String>(e.getAttendees());
+      Set<String> eAttendees = new HashSet<String>(e.getAttendees());
       Set<String> intersection = new HashSet<String>(attendees);
-      intersection.retainAll(e_attendees);
+      intersection.retainAll(eAttendees);
       if (intersection.isEmpty()) { 
         continue; // none of our attendees will be at this event
       }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -21,17 +21,14 @@ import java.util.HashSet;
 import java.util.ArrayList;
 
 public final class FindMeetingQuery {
-  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+
+  public ArrayList<TimeRange> getAvailableTimes(Collection<Event> events, Collection<String> attendees, long duration) {
     ArrayList<TimeRange> availableTimes = new ArrayList<TimeRange>();
-    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
-      // not possible for duration to exceed whole day
-      return availableTimes; 
-    }
     ArrayList<TimeRange> blockedTimes = new ArrayList<TimeRange>();
-    Set<String> r_attendees = new HashSet<String>(request.getAttendees());      
+    //Set<String> r_attendees = new HashSet<String>(request.getAttendees());      
     for (Event e : events) { // check each event of the day for blocked times
       Set<String> e_attendees = new HashSet<String>(e.getAttendees());
-      Set<String> intersection = new HashSet<String>(r_attendees);
+      Set<String> intersection = new HashSet<String>(attendees);
       intersection.retainAll(e_attendees);
       if (intersection.isEmpty()) { 
         continue; // none of our attendees will be at this event
@@ -57,14 +54,53 @@ public final class FindMeetingQuery {
     for (TimeRange t : blockedTimes) {
       int end = t.start(); 
       TimeRange good =  TimeRange.fromStartEnd(start, end, false);
-      if (good.duration() >= request.getDuration()) availableTimes.add(good);
+      if (good.duration() >= duration) availableTimes.add(good);
       start = end + t.duration(); //must resume after the event ends
     }
 
     // for the rest of the day:
     TimeRange eod =  TimeRange.fromStartEnd(start, TimeRange.END_OF_DAY, true);
-    if (eod.duration() >= request.getDuration()) availableTimes.add(eod);
+    if (eod.duration() >= duration) availableTimes.add(eod);
+    
     return availableTimes;
+  }
 
+  public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
+    ArrayList<TimeRange> availableTimesMandatory = new ArrayList<TimeRange>();
+    ArrayList<TimeRange> availableTimesOptional = new ArrayList<TimeRange>();
+    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
+      // not possible for duration to exceed whole day
+      return availableTimesMandatory; 
+    }
+
+    Collection<String> mandatoryAttendees = request.getAttendees();
+    Collection<String> optionalAttendees = request.getOptionalAttendees();
+    availableTimesMandatory = getAvailableTimes(events, mandatoryAttendees, request.getDuration());
+    availableTimesOptional = getAvailableTimes(events, optionalAttendees, request.getDuration());
+
+    if (optionalAttendees.isEmpty()) {
+      return availableTimesMandatory;
+    }
+    else if (mandatoryAttendees.isEmpty()) {
+      return availableTimesOptional;
+    }
+    else {
+      ArrayList<TimeRange> availableTimesEveryone = new ArrayList<TimeRange>();
+
+      for (TimeRange optional : availableTimesOptional) {
+        for (TimeRange mandatory : availableTimesMandatory) {
+          if (optional.start() <= mandatory.end()) {
+            int biggerStart = Math.max(optional.start(), mandatory.start());
+            int smallerEnd = Math.min(optional.end(), mandatory.end());
+            // get the smallest possible time range from the two available time slots
+            TimeRange range =  TimeRange.fromStartEnd(biggerStart, smallerEnd, false);
+            if (range.duration() >= request.getDuration()) availableTimesEveryone.add(range);
+          }
+        }
+      }
+
+      if (availableTimesEveryone.isEmpty()) return availableTimesMandatory;
+      return availableTimesEveryone;        
+    }
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/MeetingRequest.java
@@ -35,6 +35,13 @@ public final class MeetingRequest {
     this.attendees.addAll(attendees);
   }
 
+  // constructor for including optional attendees
+  public MeetingRequest(Collection<String> attendees, Collection<String> optional, long duration) {
+    this.duration = duration;
+    this.attendees.addAll(attendees);
+    this.optional_attendees.addAll(optional);
+  }
+
   /**
    * Returns a read-only copy of the people who are required to attend this meeting.
    */

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -34,10 +34,12 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
+  private static final int TIME_0845AM = TimeRange.getTimeInMinutes(8, 45);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
@@ -291,6 +293,130 @@ public final class FindMeetingQueryTest {
             Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsidered2() {
+    /* 
+     * Based on everyAttendeeIsConsidered, add an optional attendee C 
+     * who has an all-day event. The same three time slots should be returned 
+     * as when C was not invited.
+    */
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.WHOLE_DAY, Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), Arrays.asList(PERSON_C), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void everyAttendeeIsConsidered3() {
+    /*
+     * Also based on everyAttendeeIsConsidered, add an optional attendee C
+     * who has an event between 8:30 and 9:00. Now only the early and late 
+     * parts of the day should be returned. 
+    */
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)),
+        new Event("Event 3", TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES), Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), Arrays.asList(PERSON_C), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void justEnoughRoom2() {
+    /*
+     * Based on justEnoughRoom, add an optional attendee B who has an event
+     * between 8:30 and 8:45. The optional attendee should be ignored since 
+     * considering their schedule would result in a time slot smaller than 
+     * the requested time.
+    */
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 3", TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), Arrays.asList(PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void noMandatoryAttendees() {
+    /*
+     * No mandatory attendees, just two optional attendees with several gaps in 
+     * their schedules. Those gaps should be identified and returned.
+    */
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void notEnoughRoomOptional() {
+    /*
+     * No mandatory attendees, just two optional attendees with no gaps in their
+     * schedules. query should return that no time is available.
+    */
+    // Events  : |--A-----| |-----B----|
+    // Day     : |---------------------|
+    // Options :
+
+    Collection<Event> events = Arrays.asList(
+        new Event("Event 1", TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            Arrays.asList(PERSON_A)),
+        new Event("Event 2", TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+            Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(NO_ATTENDEES, Arrays.asList(PERSON_A, PERSON_B), DURATION_60_MINUTES);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -384,7 +384,7 @@ public final class FindMeetingQueryTest {
     */
     Collection<Event> events = Arrays.asList(
         new Event("Event 1", TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
-            Arrays.asList(PERSON_A)),
+            Arrays.asList(PERSON_A, PERSON_B, PERSON_C)),
         new Event("Event 2", TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
             Arrays.asList(PERSON_B)));
 


### PR DESCRIPTION
If one or more time slots exists so that both mandatory and optional attendees can attend, return those time slots. Otherwise, return the time slots that fit just the mandatory attendees.